### PR TITLE
mailchimp sync by single variant

### DIFF
--- a/app/solidus_decorators/spree/image_decorator.rb
+++ b/app/solidus_decorators/spree/image_decorator.rb
@@ -9,7 +9,7 @@ Spree::Image.class_eval do
         SolidusMailchimpSync::ProductSynchronizer.new(self.viewable.product).auto_sync(force: true)
       else
         # image just on this variant, just need to sync this one.
-        SolidusMailchimpSync::VariantSynchronizer.new(self.variant).auto_sync(force: true)
+        SolidusMailchimpSync::VariantSynchronizer.new(self.viewable).auto_sync(force: true)
       end
     end
   end


### PR DESCRIPTION
Spree:: Image doesn't longer have a `.variant` method.
So, now we take the variant from `self.viewable`